### PR TITLE
Add client build step to workflow

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -49,6 +49,20 @@ jobs:
         # remove-large-packages: 'true'
         remove-haskell: 'true'
     - uses: actions/checkout@v4
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+        cache-dependency-path: client/demo/package-lock.json
+    - name: Build client
+      shell: bash
+      run: |
+        cd client/demo
+        npx npm-check-updates -u || true
+        npm install
+        npm run build:prod
+        cd -
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -75,6 +75,20 @@ jobs:
         # remove-large-packages: 'true'
         remove-haskell: 'true'
     - uses: actions/checkout@v4
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+        cache-dependency-path: client/demo/package-lock.json
+    - name: Build client
+      shell: bash
+      run: |
+        cd client/demo
+        npx npm-check-updates -u || true
+        npm install
+        npm run build:prod
+        cd -
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ edition.txt
 tmp_dir
 dummy
 node_modules
+package-lock.json
 __pycache__
 build
 dist


### PR DESCRIPTION
## Summary
- ignore `package-lock.json`
- build client before packaging server in CI workflows

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_685a1ccb34b083229669ca2309c3d0cc