### PR TITLE
Add client SFX module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ start_trainer.sh
 
 # venv
 venv/
+server/sfx/*.wav
+client/demo/public/sfx/*.wav

--- a/client/demo/public/sfx/README.md
+++ b/client/demo/public/sfx/README.md
@@ -1,0 +1,1 @@
+Place SFX wav files here.

--- a/client/demo/src/components/demo/906_AdvancedSettingDialog.tsx
+++ b/client/demo/src/components/demo/906_AdvancedSettingDialog.tsx
@@ -191,6 +191,54 @@ export const AdvancedSettingDialog = () => {
             </div>
         );
 
+        const [sfxList, setSfxList] = React.useState<string[]>([]);
+        const reloadSfx = async () => {
+            const list = await serverSetting.getSfxList();
+            setSfxList(list);
+        };
+        const uploadSfx = async () => {
+            const file = await fileSelector("");
+            if (!file) return;
+            await serverSetting.uploadSfx(file);
+            reloadSfx();
+        };
+        const sfxRow = (
+            <div className="advanced-setting-container-row">
+                <div className="advanced-setting-container-row-title-long">SFX</div>
+                <div className="advanced-setting-container-row-field">
+                    <button onClick={reloadSfx}>Reload</button>
+                    <button onClick={uploadSfx}>Upload</button>
+                    <div>
+                        <input
+                            type="range"
+                            min="-60"
+                            max="0"
+                            step="1"
+                            value={setting.voiceChangerClientSetting.sfxTriggerLevel}
+                            onChange={(e) => {
+                                setVoiceChangerClientSetting({ ...setting.voiceChangerClientSetting, sfxTriggerLevel: Number(e.target.value) });
+                            }}
+                        />
+                        <span>{setting.voiceChangerClientSetting.sfxTriggerLevel} dB</span>
+                    </div>
+                    <div>
+                        <input
+                            type="range"
+                            min="0"
+                            max="3"
+                            step="0.1"
+                            value={setting.voiceChangerClientSetting.sfxGain}
+                            onChange={(e) => {
+                                setVoiceChangerClientSetting({ ...setting.voiceChangerClientSetting, sfxGain: Number(e.target.value) });
+                            }}
+                        />
+                        <span>{setting.voiceChangerClientSetting.sfxGain}</span>
+                    </div>
+                    <div>{sfxList.join(', ')}</div>
+                </div>
+            </div>
+        );
+
         const skipPassThroughConfirmationRow = (
             <div className="advanced-setting-container-row">
                 <div className="advanced-setting-container-row-title-long">Skip Pass through confirmation</div>
@@ -216,6 +264,7 @@ export const AdvancedSettingDialog = () => {
                 {disableJitRow}
                 {convertToOnnx}
                 {protectRow}
+                {sfxRow}
                 {skipPassThroughConfirmationRow}
             </div>
         );

--- a/client/demo/webpack.common.js
+++ b/client/demo/webpack.common.js
@@ -59,6 +59,9 @@ module.exports = {
             patterns: [{ from: "public/assets", to: "assets" }],
         }),
         new CopyPlugin({
+            patterns: [{ from: "public/sfx", to: "sfx" }],
+        }),
+        new CopyPlugin({
             patterns: [{ from: "public/favicon.ico", to: "favicon.ico" }],
         }),
 

--- a/client/lib/jest.config.js
+++ b/client/lib/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/client/lib/package.json
+++ b/client/lib/package.json
@@ -41,6 +41,7 @@
         "prettier": "^3.1.0",
         "raw-loader": "^4.0.2",
         "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.3.2",
         "webpack": "^5.89.0",

--- a/client/lib/src/VoiceChangerClient.ts
+++ b/client/lib/src/VoiceChangerClient.ts
@@ -39,9 +39,12 @@ export class VoiceChangerClient {
 
     private sem = new BlockingQueue<number>();
 
-    private sfx: SFXController;
-    private inputAnalyser: AnalyserNode;
-    private outputAnalyser: AnalyserNode;
+    /** Controller for background SFX playback. */
+    private sfx!: SFXController;
+    /** Analyser for microphone levels. */
+    private inputAnalyser!: AnalyserNode;
+    /** Analyser for output levels. */
+    private outputAnalyser!: AnalyserNode;
     private monitorTimer: number | null = null;
 
     constructor(ctx: AudioContext, vfEnable: boolean, voiceChangerWorkletListener: VoiceChangerWorkletListener) {
@@ -72,6 +75,8 @@ export class VoiceChangerClient {
             this.currentMediaStreamAudioDestinationNode = this.ctx.createMediaStreamDestination(); // output node
             this.outputGainNode = this.ctx.createGain();
             this.outputGainNode.gain.value = this.setting.outputGain;
+            this.inputAnalyser = this.ctx.createAnalyser();
+            this.outputAnalyser = this.ctx.createAnalyser();
             this.vcOutNode.connect(this.outputGainNode); // vc node -> output node
             this.vcOutNode.connect(this.outputAnalyser);
             this.outputGainNode.connect(this.currentMediaStreamAudioDestinationNode);
@@ -214,7 +219,6 @@ export class VoiceChangerClient {
         await this.vcInNode.start();
         this._isVoiceChanging = true;
         this.monitorTimer = window.setInterval(() => {
-            const now = Date.now();
             const inputDb = this.calcDb(this.inputAnalyser);
             const outputDb = this.calcDb(this.outputAnalyser);
             this.sfx.updateInputLevel(inputDb);

--- a/client/lib/src/client/ServerConfigurator.ts
+++ b/client/lib/src/client/ServerConfigurator.ts
@@ -3,8 +3,10 @@ import { ServerRestClient } from "./ServerRestClient";
 
 export class ServerConfigurator {
     private restClient;
+    serverUrl: string;
 
     constructor(serverUrl: string) {
+        this.serverUrl = serverUrl;
         this.restClient = new ServerRestClient(serverUrl);
     }
 
@@ -58,5 +60,13 @@ export class ServerConfigurator {
 
     updateModelInfo = async (slot: number, key: string, val: string) => {
         return this.restClient.updateModelInfo(slot, key, val);
+    };
+
+    getSfxList = async () => {
+        return this.restClient.getSfxList();
+    };
+
+    uploadSfx = async (file: File) => {
+        await this.restClient.uploadSfx(file);
     };
 }

--- a/client/lib/src/client/ServerRestClient.ts
+++ b/client/lib/src/client/ServerRestClient.ts
@@ -249,6 +249,20 @@ export class ServerRestClient {
         return info;
     };
 
+    getSfxList = async () => {
+        const url = this.serverUrl + "/sfx_list";
+        const info = await fetch(url, { method: "GET" });
+        return (await info.json()) as string[];
+    };
+
+    uploadSfx = async (file: File) => {
+        const url = this.serverUrl + "/upload_sfx";
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("filename", file.name);
+        await fetch(url, { method: "POST", body: formData });
+    };
+
     // VoiceChangerWorkletNodeから呼び出される
     //// Restで音声変換
     postVoice = async (timestamp: number, buffer: ArrayBuffer) => {

--- a/client/lib/src/const.ts
+++ b/client/lib/src/const.ts
@@ -355,6 +355,9 @@ export type VoiceChangerClientSetting = {
     outputGain: number;
     monitorGain: number;
 
+    sfxGain: number;
+    sfxTriggerLevel: number;
+
     passThroughConfirmationSkip: boolean;
 };
 
@@ -385,6 +388,8 @@ export const DefaultClientSettng: ClientSetting = {
         inputGain: 1.0,
         outputGain: 1.0,
         monitorGain: 1.0,
+        sfxGain: 1.0,
+        sfxTriggerLevel: -40,
         passThroughConfirmationSkip: false,
     },
 };

--- a/client/lib/src/hooks/useServerSetting.ts
+++ b/client/lib/src/hooks/useServerSetting.ts
@@ -60,6 +60,8 @@ export type ServerSettingState = {
     updateModelDefault: () => Promise<ServerInfo>;
     updateModelInfo: (slot: number, key: string, val: string) => Promise<ServerInfo>;
     uploadAssets: (slot: number, name: ModelAssetName, file: File) => Promise<void>;
+    getSfxList: () => Promise<string[]>;
+    uploadSfx: (file: File) => Promise<void>;
 };
 
 export const useServerSetting = (props: UseServerSettingProps): ServerSettingState => {
@@ -191,6 +193,16 @@ export const useServerSetting = (props: UseServerSettingProps): ServerSettingSta
         return serverInfo;
     };
 
+    const getSfxList = async () => {
+        if (!props.voiceChangerClient) return [] as string[];
+        return props.voiceChangerClient.getSfxList();
+    };
+
+    const uploadSfx = async (file: File) => {
+        if (!props.voiceChangerClient) return;
+        await props.voiceChangerClient.uploadSfx(file);
+    };
+
     return {
         serverSetting,
         updateServerSettings,
@@ -204,5 +216,7 @@ export const useServerSetting = (props: UseServerSettingProps): ServerSettingSta
         updateModelDefault,
         updateModelInfo,
         uploadAssets,
+        getSfxList,
+        uploadSfx,
     };
 };

--- a/client/lib/src/sfx/SFXController.test.js
+++ b/client/lib/src/sfx/SFXController.test.js
@@ -1,0 +1,20 @@
+const { SFXController } = require('./SFXController');
+
+class DummyAudioContext {
+    createGain() { return { gain: { value: 1 }, connect() {} }; }
+    createBufferSource() { return { buffer: null, loop: false, connect() {}, start() {}, stop() {}, disconnect() {} }; }
+}
+class DummyBuffer { constructor(){ this.duration = 1; } }
+
+test('sfx controller start and stop logic', () => {
+    const ctx = new DummyAudioContext();
+    const ctrl = new SFXController(ctx);
+    ctrl.connect({ connect() {} });
+    ctrl.load([new DummyBuffer()]);
+    ctrl.setGain(0.5);
+    ctrl.setThreshold(-30);
+    ctrl.updateInputLevel(-20);
+    expect(ctrl.playing).toBeTruthy();
+    ctrl.updateOutputLevel(-40, 1400);
+    expect(ctrl.playing).toBeFalsy();
+});

--- a/client/lib/src/sfx/SFXController.test.ts
+++ b/client/lib/src/sfx/SFXController.test.ts
@@ -1,10 +1,14 @@
 const { SFXController } = require('./SFXController');
 
 class DummyAudioContext {
-    createGain() { return { gain: { value: 1 }, connect() {} }; }
-    createBufferSource() { return { buffer: null, loop: false, connect() {}, start() {}, stop() {}, disconnect() {} }; }
+    createGain() {
+        return { gain: { value: 1 }, connect() {} } as any;
+    }
+    createBufferSource() {
+        return { buffer: null, loop: false, connect() {}, start() {}, stop() {}, disconnect() {} } as any;
+    }
 }
-class DummyBuffer { constructor(){ this.duration = 1; } }
+class DummyBuffer { duration = 1; }
 
 test('sfx controller start and stop logic', () => {
     const ctx = new DummyAudioContext();

--- a/client/lib/src/sfx/SFXController.test.ts
+++ b/client/lib/src/sfx/SFXController.test.ts
@@ -13,8 +13,19 @@ test('sfx controller start and stop logic', () => {
     ctrl.load([new DummyBuffer()]);
     ctrl.setGain(0.5);
     ctrl.setThreshold(-30);
+    // below threshold should not start playback
+    ctrl.updateInputLevel(-40);
+    expect(ctrl.playing).toBeFalsy();
+
+    // above threshold should start playback
     ctrl.updateInputLevel(-20);
     expect(ctrl.playing).toBeTruthy();
-    ctrl.updateOutputLevel(-40, 1400);
+
+    // silence shorter than limit should not stop
+    ctrl.updateOutputLevel(-40, 1000);
+    expect(ctrl.playing).toBeTruthy();
+
+    // prolonged silence stops playback
+    ctrl.updateOutputLevel(-40, 400);
     expect(ctrl.playing).toBeFalsy();
 });

--- a/client/lib/src/sfx/SFXController.ts
+++ b/client/lib/src/sfx/SFXController.ts
@@ -1,0 +1,83 @@
+/**
+ * Controller for playing background SFX.
+ * Keeps a looping AudioBufferSourceNode running at all times and adjusts gain
+ * based on detected speech levels.
+ */
+class SFXController {
+    constructor(ctx) {
+        this.ctx = ctx;
+        this.gainNode = ctx.createGain();
+        this.gainNode.gain.value = 0;
+        this.source = null;
+        this.buffer = null;
+        this.gain = 1;
+        this.thresholdDb = -40;
+        this.playing = false;
+        this.silenceMs = 0;
+    }
+
+    /** Connect SFX output to another AudioNode. */
+    connect(node) {
+        this.gainNode.connect(node);
+    }
+
+    /** Load buffers to be looped. Only the first buffer is used currently. */
+    load(buffers) {
+        if (buffers.length === 0) return;
+        this.buffer = buffers[0];
+        this.createSource();
+    }
+
+    createSource() {
+        if (!this.buffer) return;
+        if (this.source) {
+            try {
+                this.source.stop();
+            } catch (_) { /* noop */ }
+            this.source.disconnect();
+        }
+        const src = this.ctx.createBufferSource();
+        src.buffer = this.buffer;
+        src.loop = true;
+        const offset = Math.random() * this.buffer.duration;
+        src.connect(this.gainNode);
+        src.start(0, offset);
+        this.source = src;
+    }
+
+    /** Adjust gain while active. */
+    setGain(val) {
+        this.gain = val;
+        if (this.playing) this.gainNode.gain.value = val;
+    }
+
+    /** Update trigger threshold in dB. */
+    setThreshold(db) {
+        this.thresholdDb = db;
+    }
+
+    /** Update input level and start playback if exceeded. */
+    updateInputLevel(db) {
+        if (!this.playing && db > this.thresholdDb) {
+            this.playing = true;
+            this.gainNode.gain.value = this.gain;
+        }
+    }
+
+    /** Update output level and stop playback after prolonged silence. */
+    updateOutputLevel(db, dtMs) {
+        if (!this.playing) return;
+        if (db < this.thresholdDb) {
+            this.silenceMs += dtMs;
+            if (this.silenceMs >= 1300) {
+                this.playing = false;
+                this.gainNode.gain.value = 0;
+                this.silenceMs = 0;
+            }
+        } else {
+            this.silenceMs = 0;
+        }
+    }
+}
+
+module.exports = { SFXController };

--- a/client/lib/src/sfx/SFXController.ts
+++ b/client/lib/src/sfx/SFXController.ts
@@ -6,35 +6,39 @@
  * Type information is provided via JSDoc so the file can be executed as
  * plain JavaScript while still offering IntelliSense in editors.
  */
-class SFXController {
+export class SFXController {
+    /** Web Audio context used to create nodes. */
+    private ctx: AudioContext;
+    /** Output gain node controlling the SFX volume. */
+    private gainNode: GainNode;
+    /** Currently playing buffer source. */
+    private source: AudioBufferSourceNode | null = null;
+    /** Audio buffer used for looping playback. */
+    private buffer: AudioBuffer | null = null;
+    /** Gain applied when playback is active. */
+    private gain = 1;
+    /** Threshold in decibels that triggers playback. */
+    private thresholdDb = -40;
+    /** True if playback is currently audible. */
+    public playing = false;
+    /** Milliseconds of accumulated silence in the output. */
+    private silenceMs = 0;
+
     /**
-     * @param {AudioContext} ctx Web Audio context used to create nodes.
+     * Create a new controller.
+     * @param ctx WebAudio context that will own created nodes.
      */
-    constructor(ctx) {
-        /** @private @type {AudioContext} */
+    constructor(ctx: AudioContext) {
         this.ctx = ctx;
-        /** @private @type {GainNode} */
         this.gainNode = ctx.createGain();
         this.gainNode.gain.value = 0;
-        /** @private @type {AudioBufferSourceNode|null} */
-        this.source = null;
-        /** @private @type {AudioBuffer|null} */
-        this.buffer = null;
-        /** @private @type {number} */
-        this.gain = 1;
-        /** @private @type {number} */
-        this.thresholdDb = -40;
-        /** @public @type {boolean} */
-        this.playing = false;
-        /** @private @type {number} */
-        this.silenceMs = 0;
     }
 
     /**
      * Connect the SFX output to another node.
      * @param {AudioNode} node destination node
      */
-    connect(node) {
+    connect(node: AudioNode): void {
         this.gainNode.connect(node);
     }
 
@@ -43,14 +47,14 @@ class SFXController {
      * Only the first buffer of the array is used currently.
      * @param {AudioBuffer[]} buffers buffers with SFX data
      */
-    load(buffers) {
+    load(buffers: AudioBuffer[]): void {
         if (buffers.length === 0) return;
         this.buffer = buffers[0];
         this._createSource();
     }
 
     /** @private */
-    _createSource() {
+    private _createSource(): void {
         if (!this.buffer) return;
         if (this.source) {
             try {
@@ -73,7 +77,7 @@ class SFXController {
      * Set the gain to apply while playback is active.
      * @param {number} val gain value
      */
-    setGain(val) {
+    setGain(val: number): void {
         this.gain = val;
         if (this.playing) this.gainNode.gain.value = val;
     }
@@ -82,7 +86,7 @@ class SFXController {
      * Set the dB threshold that triggers playback.
      * @param {number} db threshold in decibels
      */
-    setThreshold(db) {
+    setThreshold(db: number): void {
         this.thresholdDb = db;
     }
 
@@ -91,7 +95,7 @@ class SFXController {
      * Playback starts once the threshold is exceeded.
      * @param {number} db input level in dB
      */
-    updateInputLevel(db) {
+    updateInputLevel(db: number): void {
         if (!this.playing && db > this.thresholdDb) {
             this.playing = true;
             this.gainNode.gain.value = this.gain;
@@ -104,7 +108,7 @@ class SFXController {
      * @param {number} db output level in dB
      * @param {number} dtMs elapsed milliseconds since last update
      */
-    updateOutputLevel(db, dtMs) {
+    updateOutputLevel(db: number, dtMs: number): void {
         if (!this.playing) return;
         if (db < this.thresholdDb) {
             this.silenceMs += dtMs;
@@ -119,4 +123,3 @@ class SFXController {
     }
 }
 
-module.exports = { SFXController };

--- a/client/lib/src/sfx/SFXController.ts
+++ b/client/lib/src/sfx/SFXController.ts
@@ -1,39 +1,63 @@
 /**
- * Controller for playing background SFX.
- * Keeps a looping AudioBufferSourceNode running at all times and adjusts gain
- * based on detected speech levels.
+ * Controller responsible for playing a looping sound effect (SFX).
+ *
+ * The SFX audio is kept playing in the background and its gain is
+ * automatically adjusted based on the detected input and output levels.
+ * Type information is provided via JSDoc so the file can be executed as
+ * plain JavaScript while still offering IntelliSense in editors.
  */
 class SFXController {
+    /**
+     * @param {AudioContext} ctx Web Audio context used to create nodes.
+     */
     constructor(ctx) {
+        /** @private @type {AudioContext} */
         this.ctx = ctx;
+        /** @private @type {GainNode} */
         this.gainNode = ctx.createGain();
         this.gainNode.gain.value = 0;
+        /** @private @type {AudioBufferSourceNode|null} */
         this.source = null;
+        /** @private @type {AudioBuffer|null} */
         this.buffer = null;
+        /** @private @type {number} */
         this.gain = 1;
+        /** @private @type {number} */
         this.thresholdDb = -40;
+        /** @public @type {boolean} */
         this.playing = false;
+        /** @private @type {number} */
         this.silenceMs = 0;
     }
 
-    /** Connect SFX output to another AudioNode. */
+    /**
+     * Connect the SFX output to another node.
+     * @param {AudioNode} node destination node
+     */
     connect(node) {
         this.gainNode.connect(node);
     }
 
-    /** Load buffers to be looped. Only the first buffer is used currently. */
+    /**
+     * Load the sound effect buffer.
+     * Only the first buffer of the array is used currently.
+     * @param {AudioBuffer[]} buffers buffers with SFX data
+     */
     load(buffers) {
         if (buffers.length === 0) return;
         this.buffer = buffers[0];
-        this.createSource();
+        this._createSource();
     }
 
-    createSource() {
+    /** @private */
+    _createSource() {
         if (!this.buffer) return;
         if (this.source) {
             try {
                 this.source.stop();
-            } catch (_) { /* noop */ }
+            } catch (e) {
+                /* ignore */
+            }
             this.source.disconnect();
         }
         const src = this.ctx.createBufferSource();
@@ -45,18 +69,28 @@ class SFXController {
         this.source = src;
     }
 
-    /** Adjust gain while active. */
+    /**
+     * Set the gain to apply while playback is active.
+     * @param {number} val gain value
+     */
     setGain(val) {
         this.gain = val;
         if (this.playing) this.gainNode.gain.value = val;
     }
 
-    /** Update trigger threshold in dB. */
+    /**
+     * Set the dB threshold that triggers playback.
+     * @param {number} db threshold in decibels
+     */
     setThreshold(db) {
         this.thresholdDb = db;
     }
 
-    /** Update input level and start playback if exceeded. */
+    /**
+     * Notify the controller of the current input level.
+     * Playback starts once the threshold is exceeded.
+     * @param {number} db input level in dB
+     */
     updateInputLevel(db) {
         if (!this.playing && db > this.thresholdDb) {
             this.playing = true;
@@ -64,7 +98,12 @@ class SFXController {
         }
     }
 
-    /** Update output level and stop playback after prolonged silence. */
+    /**
+     * Notify the controller of the current output level.
+     * Playback stops after 1300ms of silence under the threshold.
+     * @param {number} db output level in dB
+     * @param {number} dtMs elapsed milliseconds since last update
+     */
     updateOutputLevel(db, dtMs) {
         if (!this.playing) return;
         if (db < this.thresholdDb) {

--- a/server/const.py
+++ b/server/const.py
@@ -24,6 +24,7 @@ SERVER_DEVICE_SAMPLE_RATES = [16000, 32000, 44100, 48000, 96000, 192000]
 tmpdir = tempfile.TemporaryDirectory()
 SSL_KEY_DIR = os.path.join(tmpdir.name, "keys") if hasattr(sys, "_MEIPASS") else "keys"
 UPLOAD_DIR = os.path.join(tmpdir.name, "upload_dir") if hasattr(sys, "_MEIPASS") else "upload_dir"
+SFX_DIR = os.path.join(tmpdir.name, "sfx") if hasattr(sys, "_MEIPASS") else "sfx"
 TMP_DIR = os.path.join(tmpdir.name, "tmp_dir") if hasattr(sys, "_MEIPASS") else "tmp_dir"
 
 EDITION_FILE = os.path.join(sys._MEIPASS, "edition.txt") if hasattr(sys, "_MEIPASS") else 'edition.txt'

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ import os
 import multiprocessing as mp
 # NOTE: This is required to avoid recursive process call bug for macOS
 mp.freeze_support()
-from const import SSL_KEY_DIR, ROOT_PATH, UPLOAD_DIR, TMP_DIR, LOG_FILE, get_version, get_edition
+from const import SSL_KEY_DIR, ROOT_PATH, UPLOAD_DIR, TMP_DIR, SFX_DIR, LOG_FILE, get_version, get_edition
 # NOTE: This is required to fix current working directory on macOS
 os.chdir(ROOT_PATH)
 
@@ -99,6 +99,7 @@ async def main(args):
     os.makedirs(settings.model_dir, exist_ok=True)
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     os.makedirs(TMP_DIR, exist_ok=True)
+    os.makedirs(SFX_DIR, exist_ok=True)
 
     # HTTPS key/cert作成
     if args.https and args.https_self_signed:

--- a/server/restapi/MMVC_Rest.py
+++ b/server/restapi/MMVC_Rest.py
@@ -7,6 +7,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.exceptions import RequestValidationError
 from typing import Callable
 from voice_changer.VoiceChangerManager import VoiceChangerManager
+from const import SFX_DIR
+from restapi.MMVC_Rest_SFX import MMVC_Rest_SFX
 
 from restapi.MMVC_Rest_Hello import MMVC_Rest_Hello
 from restapi.MMVC_Rest_VoiceChanger import MMVC_Rest_VoiceChanger
@@ -56,6 +58,11 @@ class MMVC_Rest:
                 StaticFiles(directory=settings.model_dir),
                 name="static",
             )
+            app_fastapi.mount(
+                "/sfx_dir",
+                StaticFiles(directory=SFX_DIR),
+                name="static",
+            )
 
             restHello = MMVC_Rest_Hello()
             app_fastapi.include_router(restHello.router)
@@ -63,6 +70,8 @@ class MMVC_Rest:
             app_fastapi.include_router(restVoiceChanger.router)
             fileUploader = MMVC_Rest_Fileuploader(voiceChangerManager)
             app_fastapi.include_router(fileUploader.router)
+            sfxRest = MMVC_Rest_SFX()
+            app_fastapi.include_router(sfxRest.router)
 
             cls._instance = app_fastapi
             logger.info("Initialized.")

--- a/server/restapi/MMVC_Rest_SFX.py
+++ b/server/restapi/MMVC_Rest_SFX.py
@@ -1,0 +1,32 @@
+import os
+import logging
+from typing import List
+from fastapi import APIRouter, UploadFile, Form
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from restapi.mods.FileUploader import upload_file
+from const import SFX_DIR
+
+logger = logging.getLogger(__name__)
+
+class MMVC_Rest_SFX:
+    def __init__(self):
+        self.router = APIRouter()
+        self.router.add_api_route("/sfx_list", self.get_sfx_list, methods=["GET"])
+        self.router.add_api_route("/upload_sfx", self.post_upload_sfx, methods=["POST"])
+
+    def get_sfx_list(self):
+        try:
+            files = [f for f in os.listdir(SFX_DIR) if f.lower().endswith(".wav")]
+            return JSONResponse(content=jsonable_encoder(files))
+        except Exception as e:
+            logger.exception(e)
+            return JSONResponse(status_code=500, content={"error": str(e)})
+
+    def post_upload_sfx(self, file: UploadFile, filename: str = Form(...)):
+        try:
+            res = upload_file(SFX_DIR, file, filename)
+            return JSONResponse(content=jsonable_encoder(res))
+        except Exception as e:
+            logger.exception(e)
+            return JSONResponse(status_code=500, content={"error": str(e)})

--- a/server/sfx/README.md
+++ b/server/sfx/README.md
@@ -1,0 +1,1 @@
+Place WAV files here for SFX playback.


### PR DESCRIPTION
## Summary
- support SFX folder in server and expose REST API to list/upload WAV files
- enable copying of SFX files in demo webpack build
- introduce `SFXController` and integrate into `VoiceChangerClient`
- monitor audio volume to trigger and stop gapless SFX playback
- expose SFX controls in advanced settings UI
- add tests for SFXController

## Testing
- `npx --yes jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e406420c883229e29df9a62944835